### PR TITLE
update: propagate context through repositories

### DIFF
--- a/internal/application/user/usecase.go
+++ b/internal/application/user/usecase.go
@@ -42,7 +42,7 @@ func (u *userUsecase) CreateUser(ctx context.Context, displayName user.DisplayNa
 
 	newUser := user.NewUser(user.NewUserID(), identities, displayName, birthDate, now, now)
 
-	if err := u.userRepo.Create(newUser); err != nil {
+	if err := u.userRepo.Create(ctx, newUser); err != nil {
 		return nil, err
 	}
 
@@ -60,7 +60,7 @@ func (u *userUsecase) GetUser(ctx context.Context) (user.User, error) {
 		return nil, err
 	}
 
-	foundUser, err := u.userRepo.FindByIdentityID(id)
+	foundUser, err := u.userRepo.FindByIdentityID(ctx, id)
 	if errors.Is(err, identity.ErrIdentityNotFound) {
 		return nil, user.ErrUserNotFound
 	}
@@ -82,7 +82,7 @@ func (u *userUsecase) UpdateUser(ctx context.Context, displayName user.DisplayNa
 		return nil, err
 	}
 
-	foundUser, err := u.userRepo.FindByIdentityID(id)
+	foundUser, err := u.userRepo.FindByIdentityID(ctx, id)
 	if errors.Is(err, identity.ErrIdentityNotFound) {
 		return nil, user.ErrUserNotFound
 	}
@@ -92,7 +92,7 @@ func (u *userUsecase) UpdateUser(ctx context.Context, displayName user.DisplayNa
 
 	foundUser.Update(displayName, birthDate)
 
-	if err := u.userRepo.Update(foundUser); err != nil {
+	if err := u.userRepo.Update(ctx, foundUser); err != nil {
 		return nil, err
 	}
 

--- a/internal/application/user/usecase_test.go
+++ b/internal/application/user/usecase_test.go
@@ -43,7 +43,7 @@ func TestCreateUser(t *testing.T) {
 			mockAuthService := mocksappauth.NewMockAuthService(ctrl)
 			mockUserRepository := mocksuser.NewMockUserRepository(ctrl)
 			mockAuthService.EXPECT().VerifyToken(tt.ctx).Return(tt.identityID, tt.verifyTokenErr).AnyTimes()
-			mockUserRepository.EXPECT().Create(gomock.Any(), gomock.Any()).Return(tt.createErr).AnyTimes()
+			mockUserRepository.EXPECT().Create(tt.ctx, gomock.Any()).Return(tt.createErr).AnyTimes()
 
 			u := NewUserUsecase(mockAuthService, mockUserRepository)
 
@@ -86,7 +86,7 @@ func TestGetUser(t *testing.T) {
 			mockUser := mocksuser.NewMockUser(ctrl)
 			mockUserRepository := mocksuser.NewMockUserRepository(ctrl)
 			mockAuthService.EXPECT().VerifyToken(tt.ctx).Return(tt.identityID, tt.verifyTokenErr).AnyTimes()
-			mockUserRepository.EXPECT().FindByIdentityID(gomock.Any(), gomock.Any()).Return(mockUser, tt.findByIdentityIDErr).AnyTimes()
+			mockUserRepository.EXPECT().FindByIdentityID(tt.ctx, gomock.Any()).Return(mockUser, tt.findByIdentityIDErr).AnyTimes()
 
 			u := NewUserUsecase(mockAuthService, mockUserRepository)
 
@@ -135,8 +135,8 @@ func TestUpdateUser(t *testing.T) {
 			mockUser.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
 			mockUserRepository := mocksuser.NewMockUserRepository(ctrl)
 			mockAuthService.EXPECT().VerifyToken(tt.ctx).Return(tt.identityID, tt.verifyTokenErr).AnyTimes()
-			mockUserRepository.EXPECT().FindByIdentityID(gomock.Any(), gomock.Any()).Return(mockUser, tt.findByIdentityIDErr).AnyTimes()
-			mockUserRepository.EXPECT().Update(gomock.Any(), gomock.Any()).Return(tt.updateErr).AnyTimes()
+			mockUserRepository.EXPECT().FindByIdentityID(tt.ctx, gomock.Any()).Return(mockUser, tt.findByIdentityIDErr).AnyTimes()
+			mockUserRepository.EXPECT().Update(tt.ctx, gomock.Any()).Return(tt.updateErr).AnyTimes()
 
 			u := NewUserUsecase(mockAuthService, mockUserRepository)
 

--- a/internal/application/user/usecase_test.go
+++ b/internal/application/user/usecase_test.go
@@ -43,7 +43,7 @@ func TestCreateUser(t *testing.T) {
 			mockAuthService := mocksappauth.NewMockAuthService(ctrl)
 			mockUserRepository := mocksuser.NewMockUserRepository(ctrl)
 			mockAuthService.EXPECT().VerifyToken(tt.ctx).Return(tt.identityID, tt.verifyTokenErr).AnyTimes()
-			mockUserRepository.EXPECT().Create(gomock.Any()).Return(tt.createErr).AnyTimes()
+			mockUserRepository.EXPECT().Create(gomock.Any(), gomock.Any()).Return(tt.createErr).AnyTimes()
 
 			u := NewUserUsecase(mockAuthService, mockUserRepository)
 
@@ -86,7 +86,7 @@ func TestGetUser(t *testing.T) {
 			mockUser := mocksuser.NewMockUser(ctrl)
 			mockUserRepository := mocksuser.NewMockUserRepository(ctrl)
 			mockAuthService.EXPECT().VerifyToken(tt.ctx).Return(tt.identityID, tt.verifyTokenErr).AnyTimes()
-			mockUserRepository.EXPECT().FindByIdentityID(gomock.Any()).Return(mockUser, tt.findByIdentityIDErr).AnyTimes()
+			mockUserRepository.EXPECT().FindByIdentityID(gomock.Any(), gomock.Any()).Return(mockUser, tt.findByIdentityIDErr).AnyTimes()
 
 			u := NewUserUsecase(mockAuthService, mockUserRepository)
 
@@ -135,8 +135,8 @@ func TestUpdateUser(t *testing.T) {
 			mockUser.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
 			mockUserRepository := mocksuser.NewMockUserRepository(ctrl)
 			mockAuthService.EXPECT().VerifyToken(tt.ctx).Return(tt.identityID, tt.verifyTokenErr).AnyTimes()
-			mockUserRepository.EXPECT().FindByIdentityID(gomock.Any()).Return(mockUser, tt.findByIdentityIDErr).AnyTimes()
-			mockUserRepository.EXPECT().Update(gomock.Any()).Return(tt.updateErr).AnyTimes()
+			mockUserRepository.EXPECT().FindByIdentityID(gomock.Any(), gomock.Any()).Return(mockUser, tt.findByIdentityIDErr).AnyTimes()
+			mockUserRepository.EXPECT().Update(gomock.Any(), gomock.Any()).Return(tt.updateErr).AnyTimes()
 
 			u := NewUserUsecase(mockAuthService, mockUserRepository)
 

--- a/internal/domain/user/repository.go
+++ b/internal/domain/user/repository.go
@@ -1,10 +1,14 @@
 package user
 
-import "github.com/qkitzero/user-service/internal/domain/identity"
+import (
+	"context"
+
+	"github.com/qkitzero/user-service/internal/domain/identity"
+)
 
 type UserRepository interface {
-	Create(user User) error
-	FindByIdentityID(identityID identity.IdentityID) (User, error)
-	FindByID(userID UserID) (User, error)
-	Update(user User) error
+	Create(ctx context.Context, user User) error
+	FindByIdentityID(ctx context.Context, identityID identity.IdentityID) (User, error)
+	FindByID(ctx context.Context, userID UserID) (User, error)
+	Update(ctx context.Context, user User) error
 }

--- a/internal/infrastructure/user/repository.go
+++ b/internal/infrastructure/user/repository.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"errors"
 
 	"gorm.io/gorm"
@@ -18,8 +19,8 @@ func NewUserRepository(db *gorm.DB) user.UserRepository {
 	return &userRepository{db: db}
 }
 
-func (r *userRepository) Create(u user.User) error {
-	return r.db.Transaction(func(tx *gorm.DB) error {
+func (r *userRepository) Create(ctx context.Context, u user.User) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		userModel := UserModel{
 			ID:          u.ID(),
 			DisplayName: u.DisplayName(),
@@ -48,9 +49,9 @@ func (r *userRepository) Create(u user.User) error {
 	})
 }
 
-func (r *userRepository) FindByIdentityID(id identity.IdentityID) (user.User, error) {
+func (r *userRepository) FindByIdentityID(ctx context.Context, id identity.IdentityID) (user.User, error) {
 	var identityModel infraidentity.IdentityModel
-	err := r.db.Where("id = ?", id).First(&identityModel).Error
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&identityModel).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, identity.ErrIdentityNotFound
 	}
@@ -59,7 +60,7 @@ func (r *userRepository) FindByIdentityID(id identity.IdentityID) (user.User, er
 	}
 
 	var userModel UserModel
-	err = r.db.Where("id = ?", identityModel.UserID).First(&userModel).Error
+	err = r.db.WithContext(ctx).Where("id = ?", identityModel.UserID).First(&userModel).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, user.ErrUserNotFound
 	}
@@ -68,7 +69,7 @@ func (r *userRepository) FindByIdentityID(id identity.IdentityID) (user.User, er
 	}
 
 	var identityModels []infraidentity.IdentityModel
-	if err := r.db.Where("user_id = ?", userModel.ID).Find(&identityModels).Error; err != nil {
+	if err := r.db.WithContext(ctx).Where("user_id = ?", userModel.ID).Find(&identityModels).Error; err != nil {
 		return nil, err
 	}
 
@@ -87,9 +88,9 @@ func (r *userRepository) FindByIdentityID(id identity.IdentityID) (user.User, er
 	), nil
 }
 
-func (r *userRepository) FindByID(id user.UserID) (user.User, error) {
+func (r *userRepository) FindByID(ctx context.Context, id user.UserID) (user.User, error) {
 	var userModel UserModel
-	err := r.db.Where("id = ?", id).First(&userModel).Error
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&userModel).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, user.ErrUserNotFound
 	}
@@ -98,7 +99,7 @@ func (r *userRepository) FindByID(id user.UserID) (user.User, error) {
 	}
 
 	var identityModels []infraidentity.IdentityModel
-	if err := r.db.Where("user_id = ?", userModel.ID).Find(&identityModels).Error; err != nil {
+	if err := r.db.WithContext(ctx).Where("user_id = ?", userModel.ID).Find(&identityModels).Error; err != nil {
 		return nil, err
 	}
 
@@ -117,8 +118,8 @@ func (r *userRepository) FindByID(id user.UserID) (user.User, error) {
 	), nil
 }
 
-func (r *userRepository) Update(u user.User) error {
-	return r.db.Transaction(func(tx *gorm.DB) error {
+func (r *userRepository) Update(ctx context.Context, u user.User) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		userModel := UserModel{
 			ID:          u.ID(),
 			DisplayName: u.DisplayName(),

--- a/internal/infrastructure/user/repository_test.go
+++ b/internal/infrastructure/user/repository_test.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"testing"
@@ -107,7 +108,7 @@ func TestCreate(t *testing.T) {
 
 			repo := NewUserRepository(gormDB)
 
-			err = repo.Create(mockUser)
+			err = repo.Create(context.Background(), mockUser)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -244,7 +245,7 @@ func TestFindByIdentityID(t *testing.T) {
 
 			repo := NewUserRepository(gormDB)
 
-			_, err = repo.FindByIdentityID(tt.identityID)
+			_, err = repo.FindByIdentityID(context.Background(), tt.identityID)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -340,7 +341,7 @@ func TestFindByID(t *testing.T) {
 
 			repo := NewUserRepository(gormDB)
 
-			_, err = repo.FindByID(tt.userID)
+			_, err = repo.FindByID(context.Background(), tt.userID)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -421,7 +422,7 @@ func TestUpdate(t *testing.T) {
 
 			repo := NewUserRepository(gormDB)
 
-			err = repo.Update(mockUser)
+			err = repo.Update(context.Background(), mockUser)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}

--- a/mocks/domain/user/mock_repository.go
+++ b/mocks/domain/user/mock_repository.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	identity "github.com/qkitzero/user-service/internal/domain/identity"
@@ -42,59 +43,59 @@ func (m *MockUserRepository) EXPECT() *MockUserRepositoryMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockUserRepository) Create(arg0 user.User) error {
+func (m *MockUserRepository) Create(ctx context.Context, arg1 user.User) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", arg0)
+	ret := m.ctrl.Call(m, "Create", ctx, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockUserRepositoryMockRecorder) Create(arg0 any) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) Create(ctx, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockUserRepository)(nil).Create), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockUserRepository)(nil).Create), ctx, arg1)
 }
 
 // FindByID mocks base method.
-func (m *MockUserRepository) FindByID(userID user.UserID) (user.User, error) {
+func (m *MockUserRepository) FindByID(ctx context.Context, userID user.UserID) (user.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindByID", userID)
+	ret := m.ctrl.Call(m, "FindByID", ctx, userID)
 	ret0, _ := ret[0].(user.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindByID indicates an expected call of FindByID.
-func (mr *MockUserRepositoryMockRecorder) FindByID(userID any) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) FindByID(ctx, userID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockUserRepository)(nil).FindByID), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockUserRepository)(nil).FindByID), ctx, userID)
 }
 
 // FindByIdentityID mocks base method.
-func (m *MockUserRepository) FindByIdentityID(identityID identity.IdentityID) (user.User, error) {
+func (m *MockUserRepository) FindByIdentityID(ctx context.Context, identityID identity.IdentityID) (user.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindByIdentityID", identityID)
+	ret := m.ctrl.Call(m, "FindByIdentityID", ctx, identityID)
 	ret0, _ := ret[0].(user.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindByIdentityID indicates an expected call of FindByIdentityID.
-func (mr *MockUserRepositoryMockRecorder) FindByIdentityID(identityID any) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) FindByIdentityID(ctx, identityID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByIdentityID", reflect.TypeOf((*MockUserRepository)(nil).FindByIdentityID), identityID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByIdentityID", reflect.TypeOf((*MockUserRepository)(nil).FindByIdentityID), ctx, identityID)
 }
 
 // Update mocks base method.
-func (m *MockUserRepository) Update(arg0 user.User) error {
+func (m *MockUserRepository) Update(ctx context.Context, arg1 user.User) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", arg0)
+	ret := m.ctrl.Call(m, "Update", ctx, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockUserRepositoryMockRecorder) Update(arg0 any) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) Update(ctx, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockUserRepository)(nil).Update), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockUserRepository)(nil).Update), ctx, arg1)
 }


### PR DESCRIPTION
## Summary
- Add `ctx context.Context` as the first argument of every method on `UserRepository`
- Update the GORM implementation to call `r.db.WithContext(ctx)` (including inside `Transaction`)
- Propagate the handler `ctx` through `internal/application/user/usecase.go` to the repository
- Regenerate mocks; update test call sites to pass `context.Background()`

Closes #206.

## Notes
- Mirrors the pattern from [workout-service#16](https://github.com/qkitzero/workout-service/pull/16) (commit `update: propagate context through repositories`)
- Out of scope: handler-level deadlines, OpenTelemetry — this PR only wires the plumbing

## Test plan
- [x] `go test ./...` passes
- [x] `make mock-gen` produces clean mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)