### PR TITLE
docs: document the group feature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,23 @@ classDiagram
         id
     }
 
+    class Group {
+        id
+        name
+        createdAt
+        updatedAt
+    }
+
+    class Membership {
+        id
+        role
+        joinedAt
+    }
+
     User "1" -- "0..*" Identity
+    User "1" -- "0..*" Membership
+    Group "1" -- "0..*" Membership
+    Group "0..*" -- "0..*" Group
 ```
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ classDiagram
     User "1" -- "0..*" Identity
     User "1" -- "0..*" Membership
     Group "1" -- "0..*" Membership
-    Group "0..*" -- "0..*" Group
+    Group "0..*" -- "0..*" Group : parent/child
 ```
 
 ```mermaid


### PR DESCRIPTION
## Summary

Document the group feature (#216) in the README, which previously described only the `User` and `Identity` entities.

## Changes

- Extend the entity (class) `mermaid` diagram with:
  - `Group` and `Membership` classes
  - `User` — `Membership` and `Group` — `Membership` relations
  - many-to-many parent/child relation between `Group`s (matching the `group_relations` composite primary key)

## Notes

- Diagram-only update; no prose section was added.
- Membership `role` reflects the domain roles (`owner`, `admin`, `member`).

Closes #220