### PR TITLE
docs: add Lint workflow badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![release](https://img.shields.io/github/v/release/qkitzero/user-service?logo=github)](https://github.com/qkitzero/user-service/releases)
 [![test](https://github.com/qkitzero/user-service/actions/workflows/test.yml/badge.svg)](https://github.com/qkitzero/user-service/actions/workflows/test.yml)
+[![Lint](https://github.com/qkitzero/user-service/actions/workflows/lint.yml/badge.svg)](https://github.com/qkitzero/user-service/actions/workflows/lint.yml)
 [![codecov](https://codecov.io/gh/qkitzero/user-service/graph/badge.svg)](https://codecov.io/gh/qkitzero/user-service)
 [![Buf CI](https://github.com/qkitzero/user-service/actions/workflows/buf-ci.yaml/badge.svg)](https://github.com/qkitzero/user-service/actions/workflows/buf-ci.yaml)
 


### PR DESCRIPTION
## Summary

The `Lint` workflow (`.github/workflows/lint.yml`) runs golangci-lint on this repository, but the README did not display a Lint status badge. Other workflows (test, codecov, Buf CI) already have badges, so add the Lint badge for consistency.

## Changes

- Add the `Lint` badge to the README, placed alongside the existing CI badges (after `test`, before `codecov`). It links to the Lint workflow runs.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)