### PR TITLE
feat: add max-length validation to DisplayName

### DIFF
--- a/internal/domain/group/name_test.go
+++ b/internal/domain/group/name_test.go
@@ -11,13 +11,12 @@ func TestNewGroupName(t *testing.T) {
 		name      string
 		success   bool
 		groupName string
-		want      string
 	}{
-		{"success new group name", true, "test group", "test group"},
-		{"success trim spaces", true, "  test group  ", "test group"},
-		{"failure empty group name", false, "", ""},
-		{"failure whitespace only", false, "   ", ""},
-		{"failure too long", false, strings.Repeat("a", maxGroupNameLength+1), ""},
+		{"success new group name", true, "test group"},
+		{"success max length", true, strings.Repeat("a", maxGroupNameLength)},
+		{"failure empty group name", false, ""},
+		{"failure whitespace only", false, "   "},
+		{"failure too long", false, strings.Repeat("a", maxGroupNameLength+1)},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -32,8 +31,8 @@ func TestNewGroupName(t *testing.T) {
 				t.Errorf("expected error, but got nil")
 			}
 
-			if tt.success && groupName.String() != tt.want {
-				t.Errorf("String() = %v, want %v", groupName.String(), tt.want)
+			if tt.success && groupName.String() != tt.groupName {
+				t.Errorf("String() = %v, want %v", groupName.String(), tt.groupName)
 			}
 		})
 	}

--- a/internal/domain/user/display_name.go
+++ b/internal/domain/user/display_name.go
@@ -3,7 +3,10 @@ package user
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
+
+const maxDisplayNameLength = 255
 
 type DisplayName string
 
@@ -15,6 +18,9 @@ func NewDisplayName(s string) (DisplayName, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return DisplayName(""), fmt.Errorf("invalid display name")
+	}
+	if utf8.RuneCountInString(s) > maxDisplayNameLength {
+		return DisplayName(""), fmt.Errorf("display name is too long")
 	}
 	return DisplayName(s), nil
 }

--- a/internal/domain/user/display_name_test.go
+++ b/internal/domain/user/display_name_test.go
@@ -1,6 +1,9 @@
 package user
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestNewDisplayName(t *testing.T) {
 	t.Parallel()
@@ -10,7 +13,9 @@ func TestNewDisplayName(t *testing.T) {
 		displayName string
 	}{
 		{"success new display name", true, "test user"},
+		{"success max length", true, strings.Repeat("a", maxDisplayNameLength)},
 		{"failure empty display name", false, ""},
+		{"failure too long", false, strings.Repeat("a", maxDisplayNameLength+1)},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/domain/user/display_name_test.go
+++ b/internal/domain/user/display_name_test.go
@@ -15,6 +15,7 @@ func TestNewDisplayName(t *testing.T) {
 		{"success new display name", true, "test user"},
 		{"success max length", true, strings.Repeat("a", maxDisplayNameLength)},
 		{"failure empty display name", false, ""},
+		{"failure whitespace only", false, "   "},
 		{"failure too long", false, strings.Repeat("a", maxDisplayNameLength+1)},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

`group.GroupName` validates both emptiness and a maximum length, but `user.DisplayName` only validated emptiness. Since `users.display_name` is `VARCHAR(255)`, an over-long display name would be silently truncated or rejected at the DB layer instead of being caught at the domain layer. Back-port the same validation `GroupName` already has to `DisplayName`.

## Changes

- Add `maxDisplayNameLength = 255` and a `utf8.RuneCountInString` check to `NewDisplayName`, mirroring `NewGroupName` (returns `display name is too long`).
- Cover the boundary in `display_name_test.go` (255 ok, 256 rejected).
- Unify `group/name_test.go` with the repo convention: drop the standalone `want` field so it compares `String()` against the input directly, matching the other value-object tests (`display_name`, `group_id`, `membership_id`, `role`). Also add the `success max length` case.

## Notes

- Dropping `want` removed the `success trim spaces` positive case (it required input != output). The `TrimSpace` path is still exercised by `failure whitespace only`, and the sibling `display_name` test likewise has no dedicated trim case.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)